### PR TITLE
Attempting to fix 'Cannot open display :0.0'

### DIFF
--- a/.local/bin/i3cmds/dmenurecord
+++ b/.local/bin/i3cmds/dmenurecord
@@ -32,7 +32,7 @@ screencast() { \
 	-f x11grab \
 	-framerate 60 \
 	-s $(xdpyinfo | grep dimensions | awk '{print $2;}') \
-	-i :0.0 \
+	-i $DISPLAY \
 	-f alsa -i default \
 	-r 30 \
  	-c:v libx264rgb -crf 0 -preset ultrafast -c:a flac \
@@ -44,7 +44,7 @@ screencast() { \
 video() { ffmpeg \
 	-f x11grab \
 	-s $(xdpyinfo | grep dimensions | awk '{print $2;}') \
-	-i :0.0 \
+	-i $DISPLAY \
  	-c:v libx264 -qp 0 -r 30 \
 	"$HOME/video-$(date '+%y%m%d-%H%M-%S').mkv" &
 	echo $! > /tmp/recordingpid


### PR DESCRIPTION
When attempting to run dmenurecord for screnacast or video it kinda dies silently with :

```
Invalid MIT-MAGIC-COOKIE-1 key[x11grab @ 0x5558eb7d5240] Cannot open display :0.0, error 1.
:0.0: Input/output error
```
Must be my bloated setup, but would it not be better to use value of _$DISPLAY_ instead of _:0.0_ as value for _-i_ argument  